### PR TITLE
feat: Add llms.txt generation for LLM content discovery

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -4,6 +4,20 @@ languageCode = 'zh-cn'
 title = 'Joe'
 theme = 'PaperMod'
 
+# Custom output format for llms.txt
+[outputFormats]
+  [outputFormats.llmstxt]
+    name = "llmstxt"
+    mediaType = "text/plain"
+    baseName = "llms"
+    path = ""
+    isPlainText = true
+    notAlternative = true
+
+# Add llmstxt to home page outputs
+[outputs]
+  home = ["HTML", "RSS", "llmstxt"]
+
 [imaging]
 # 默认重采样过滤器，用于调整大小
 resampleFilter = "box"

--- a/layouts/_default/home.llmstxt
+++ b/layouts/_default/home.llmstxt
@@ -1,0 +1,25 @@
+# {{ .Site.Title }} - LLM Content Index
+# Generated: {{ now.Format "2006-01-02T15:04:05Z07:00" }}
+# Base URL: {{ .Site.BaseURL }}
+# Language: {{ .Site.LanguageCode }}
+{{- if .Site.Params.description }}
+# Description: {{ .Site.Params.description }}
+{{- end }}
+
+{{- $pages := .Site.RegularPages }}
+{{- if $pages }}
+# Articles (newest first)
+{{ range $pages.ByDate.Reverse }}
+{{- if not .Draft }}
+{{- $category := "Uncategorized" }}
+{{- if .Params.categories }}
+  {{- $category = index .Params.categories 0 }}
+  {{- if eq $category "人工智能" }}{{ $category = "AI" }}{{ end }}
+  {{- $category = title $category }}
+{{- end }}
+{{ .Date.Format "2006-01-02" }} {{ $category }} {{ .Title }} - {{ .Permalink }}
+{{- end }}
+{{- end }}
+{{- else }}
+# No articles available
+{{- end }}


### PR DESCRIPTION
## Summary
Implement llms.txt file generation to enable LLMs to discover and understand website content structure.

## Changes
- Added custom Hugo output format configuration for llms.txt
- Created `layouts/_default/home.llmstxt` template
- Automatic generation during Hugo build process
- Articles sorted by date (newest first)
- Category mapping for better readability (人工智能 → AI, etc.)

## Implementation Details
- **File size**: ~1KB (well under 100KB limit)
- **Encoding**: UTF-8 with Unix line endings
- **Format**: Simple text format optimized for LLM parsing
- **Content**: Site metadata + article list with date, category, title, and URL

## Test Plan
- [x] Hugo build succeeds without errors
- [x] llms.txt generated at public/llms.txt
- [x] File contains correct site metadata
- [x] Articles listed in newest-first order
- [x] Categories properly mapped
- [x] URLs are absolute and correct
- [x] File size under limit
- [x] UTF-8 encoding verified

## Example Output
\`\`\`
# Joe - LLM Content Index
# Generated: 2025-09-30T17:14:35+08:00
# Base URL: https://fists.cc/
# Language: zh-cn
# Articles (newest first)

2025-09-30 AI技术 多智能体系统的本质... - https://fists.cc/posts/ai/multi-agent-analysis/
2025-09-25 Ai Context Engineering... - https://fists.cc/posts/ai/context-engineering/
...
\`\`\`

Generated with Claude Code